### PR TITLE
update cwd() utility function to use __name__ and Path.cwd()

### DIFF
--- a/epimargin/utils.py
+++ b/epimargin/utils.py
@@ -16,10 +16,10 @@ annually = 1/years
 million  = 1e6
 
 def cwd() -> Path:
-    argv0 = sys.argv[0]
-    if argv0.endswith("ipython"):
-        return Path(".").resolve()
-    return Path(argv0).resolve().parent
+    try:
+        return Path(__file__).resolve().parent
+    except NameError:
+        return Path.cwd()
         
 def fmt_params(**kwargs) -> str:
     """  get useful experiment tag from a dictionary of experiment settings """


### PR DESCRIPTION
Changes the `cwd` utility function to use builtins like `__file__` to get the script directory; when that fails, use the current working directory as specified by `pathlib.Path.cwd()`.

Closes #116 