### PR TITLE
fix version number typo for `zipp` requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -93,4 +93,4 @@ Werkzeug==1.0.1
 wrapt==1.12.1
 xarray==0.15.1
 xlrd==1.2.0
-zipp==4.1.0
+zipp==3.1.0


### PR DESCRIPTION
Should be version 3.1.0

Closes #115 