### PR TITLE
fix argv reading in ipython

### DIFF
--- a/.github/workflows/tutorial-ci.yaml
+++ b/.github/workflows/tutorial-ci.yaml
@@ -18,9 +18,6 @@ jobs:
       - name: Install
         run: |
           python setup.py install
-      - name: install extra to run studies
-        run: |
-          python -m pip install tqdm
       - name: Run tutorial
         run: |
-          cd docs/ && python tutorial.py
+          cd docs/ && python tutorial.py headless

--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -1,11 +1,20 @@
 # preliminary set up
 from itertools import cycle
+import sys
 
 import epimargin.plots as plt
 import numpy as np
 import pandas as pd
 from epimargin.utils import setup
 
+# don't block plots when running in headless mode in CI
+if "headless" in sys.argv:
+    sys.argv.remove("headless")
+    block_figs = False
+else:
+    block_figs = True
+
+# set up directories and set plot theme
 (data, figs) = setup()
 plt.set_theme("minimal")
 
@@ -47,7 +56,7 @@ plt.PlotDevice()\
     .format_xaxis()\
     .size(9.5, 6)\
     .save(figs / "fig_1.svg")\
-    .show(block = False)
+    .show(block = block_figs)
 
 # estimate Rt 
 from epimargin.estimators import analytical_MPVS
@@ -59,7 +68,7 @@ plt.Rt(dates[1:], Rt[1:], Rt_CI_upper[1:], Rt_CI_lower[1:], 0.95, legend_loc = "
     .adjust(bottom = 0.15, left = 0.15)\
     .size(9.5, 6)\
     .save(figs / "fig_2.svg")\
-    .show(block = False)
+    .show(block = block_figs)
 
 # set up model
 from epimargin.models import SIR
@@ -107,4 +116,4 @@ plt.PlotDevice()\
     .size(9.5, 6)\
     .format_xaxis()\
     .save(figs / "fig_3.svg")\
-    .show(block = False)
+    .show(block = block_figs)

--- a/epimargin/plots.py
+++ b/epimargin/plots.py
@@ -90,9 +90,9 @@ substack_settings = Aesthetics(
 )
 
 theme = default_settings = Aesthetics(
-    title   = {"size": 28, "family": "Helvetica Neue", "weight": "500"},
-    label   = {"size": 20, "family": "Helvetica Neue", "weight": "500"},
-    note    = {"size": 14, "family": "Helvetica Neue", "weight": "500"},
+    title   = {"size": 28, "family": "Helvetica Neue", "weight": "regular"},
+    label   = {"size": 20, "family": "Helvetica Neue", "weight": "regular"},
+    note    = {"size": 14, "family": "Helvetica Neue", "weight": "regular"},
     ticks   = {"size": 10, "family": "Helvetica Neue"},
     style   = "whitegrid",
     palette = "bright",
@@ -103,9 +103,9 @@ theme = default_settings = Aesthetics(
 )
 
 minimal_settings = Aesthetics(
-    title   = {"size": 28, "family": "Helvetica Neue", "weight": "500"},
-    label   = {"size": 20, "family": "Helvetica Neue", "weight": "500"},
-    note    = {"size": 14, "family": "Helvetica Neue", "weight": "500"},
+    title   = {"size": 28, "family": "Helvetica Neue", "weight": "regular"},
+    label   = {"size": 20, "family": "Helvetica Neue", "weight": "regular"},
+    note    = {"size": 14, "family": "Helvetica Neue", "weight": "regular"},
     ticks   = {"size": 12, "family": "Helvetica Neue"},
     style   = "white",
     palette = "bright",

--- a/epimargin/utils.py
+++ b/epimargin/utils.py
@@ -37,7 +37,7 @@ def setup(**kwargs) -> Tuple[Path, ...]:
     if len(sys.argv) > 2:
         parser = argparse.ArgumentParser()
         parser.add_argument("--level", type=str)
-        flags = parser.parse_args()
+        flags = parser.parse_args(args = [] if len(sys.argv) == 1 else sys.argv[1:])
         kwargs["level"] = flags.level
     logging.basicConfig(**kwargs)
     logging.getLogger('flat_table').addFilter(lambda _: 0)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "pandas",
         "matplotlib",
         "arviz",
-        "pymc3",
+        "pymc3==3.11.2",
         "statsmodels",
         "flat-table",
         "requests",


### PR DESCRIPTION
bugfix for issues brought up in https://github.com/openjournals/joss-reviews/issues/3464

- pass `argv` explicitly to `parser.parse_args()` to ensure compatibility with ipython's arg parsing
- add a headless flag to tutorial to allow running in CI without blocking on plot generation